### PR TITLE
Fix order of init in MKCDATA/c

### DIFF
--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -287,18 +287,18 @@ char* GETSTROFF(VAL stroff) {
 }
 
 VAL MKCDATA(VM* vm, CHeapItem * item) {
+    c_heap_insert_if_needed(vm, &vm->c_heap, item);
     Closure* cl = allocate(sizeof(Closure), 0);
     SETTY(cl, CDATA);
     cl->info.c_heap_item = item;
-    c_heap_insert_if_needed(vm, &vm->c_heap, item);
     return cl;
 }
 
 VAL MKCDATAc(VM* vm, CHeapItem * item) {
+    c_heap_insert_if_needed(vm, &vm->c_heap, item);
     Closure* cl = allocate(sizeof(Closure), 1);
     SETTY(cl, CDATA);
     cl->info.c_heap_item = item;
-    c_heap_insert_if_needed(vm, &vm->c_heap, item);
     return cl;
 }
 

--- a/test/primitives006/load-test.idr
+++ b/test/primitives006/load-test.idr
@@ -39,8 +39,8 @@ alloc x i = do
 
 main : IO ()
 main = do
-    -- First allocate 4096 64M arrays to break the C heap if there's a bug
-    alloc 0 4096 >>= printLn
+    -- First allocate 1024 64M arrays to break the C heap if there's a bug
+    alloc 0 1024 >>= printLn
 
     -- Then, test Bytes
     traverse_ (unit n . prim__truncInt_B8) [1..n]


### PR DESCRIPTION
The creation of the item could cause a collection making the pointer to the closure invalid.

Also, make the test slightly gentler to stop it from exhausting the default stack size on Windows.
